### PR TITLE
Word tree #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Password *Genie*rator
 Solution to generate passwords using different algorithms: randomized, dictionary. The purpose of this project is to provide a way to generate easy to remember and type passwords but that are difficult to guess.
 
-## Usage
+## Generation usage
 To use the console application, run the following command:
 ```bash
 genpwd generate <strategy> [options]
@@ -48,22 +48,22 @@ When the same hand is used for a word, the keystrokes will avoid using the same 
 ./genpwd generate random -p 5 -l 16 -n 2 -s 2 -c 12
 ```
 ```
-W}7IIrnPltDNV8D&
-X8TmC\sKWRnV6,jb
-M\iVXLbw0trVB9d)
-bpCpV;|SSaW6xYF0
-HjcAwh}_9uKVLr9d
+D4,5e-iPhGxYlXzh
+fL^63/vFvNKBwKzU
+Pq,g-q88QBJXOnJV
+LnT,iA8)4LfXjeSe
+p06}eb@iOMuEnfIy
 ```
 ### Dictionary Strategy
 ```bash
 ./genpwd generate dictionary -d /usr/share/dict/words -p 5 -w 3 -wl 8 -wd 2
 ```
 ```
-Zuilkyu%EyipmkThwynao6
-Blyc[TimphilyclPnxinu1
-Luhupmk"IulipDjiulilih5
-Xrewe%AgdseavdYnarqerabe3
-Dypoilihril|IopilkPheohm5
+Devu+PloltrierkbMseo9
+Vssiveig"NhespobHf3
+Lerndojiur(BmDbrldgavg4
+Ukuarfs$PshfNactrtweri1
+Xosluoel"XyzafPaml7
 ```
 ### Author's favorite
 
@@ -71,16 +71,29 @@ Dypoilihril|IopilkPheohm5
 ./genpwd generate dictionary -d /usr/share/dict/words -p 10 -l 12 -w 2 -n 1 -s 1 -sc "-." -wl 6 -wd 4 -ko AlternatingStroke
 ```
 ```
-Vorham-Peytor9
-Skryen-Clayshf0
-Naotocl.Iantheu9
-Yakaneh-Lemanakt0
-Thwitoth-Nahant9
-Henbibi-Ovispr1
-Qiblahs.Bkbndo2
-Ovibot.Thwitl0
-Vocodp-Oghamale8
-Qiblauwi-Leuchan2
+Zoeheu.Gneu7
+Yclepe.Ndod5
+Hsuant.Jayan7
+Dodoel-Zizy4
+Blamsi.Epen4
+Yblentor-Iwis5
+Jahantix-Udog5
+Giti-Zytheo4
+Iantheya-Mzu9
+Flanchau-Tnt5
+```
+
+## Extraction usage
+With this application it's possible to create a word tree file to use it later in the generation process. Word tree files could be smaller than dictionary files, they contain a tree structure of letters with all of the possible letter sequences extracted from the dictionary.
+
+### Options
+- `--Input`, `-i`: File path for the dictionary file.
+- `--Output`, `-o`: File path for the generated word tree file.
+- `--Overwrite`, `-ow`: Overwrite the output file if it already exists.
+
+```bash
+./genpwd extract plain -i /usr/share/dict/words -o /home/user/pass-genie/word-tree.dat.gz
+./genpwd generate dictionary -wt /home/user/pass-genie/word-tree.dat.gz -p 10 -l 12 -w 2 -n 1 -s 1 -sc "-." -wl 6 -wd 4 -ko AlternatingStroke
 ```
 
 # The Solution
@@ -90,20 +103,19 @@ This is a **n-layer** solution that provides a way to generate passwords using d
   - *pg-shared*: This project contains the common classes for the solution.
   - *pg-entities*: This project contains the entities for the solution. Only the entities that must traverse all the layers are included here.
 - **Data Access layer**: Provides the data access to the dictionary file. Its main purpose is to read the data requested by the logic layer.
-  - *pg-data-files*: Data access methods for managing files (dictionaries). Any other dictionary type can be implemented here in the future.
+  - *pg-data-files*: Data access methods for managing files (dictionaries, word trees, ...). Any other dictionary type can be implemented here.
 - **Logic layer**: This layer contains only logic, external data and interactions are handled by the interface layer.
   - *pg-logic*: This project contains the main logic to generate the passwords. It's divided into the following sub-layers:
     - Generators: Contains the classes to generate the passwords using different strategies. New strategies can be implemented here.
     - Loaders: Contains the classes to load the data from the data access layer. The data layer is responsible to provide a list of words, and the logic layer will use them to create the necessary structure to generate the passwords. This structure is loaded only once and kept in memory.
 - **Interface layer**: This layer is responsible for the communication between the external world and the logic layer. It will convert external data and interactions into entities and actions that the logic layer can understand. It will also convert the results from the logic layer into a format that the external world can understand.
   - *pg-interface-cmd*: Provides the command line parsing for the console application and defines the commands and options available. It will also handle the exceptions and pass a human-readable message to the caller.
-- **Console application**: Provides the console application to generate the passwords and outputs the messages to the user. Any other console commands can be implemented here in the future.
-	- *pg-console-genpwd*: Entry point for the genpwd command.
+  - *pg-wasm-pwdgen*: Web application that acts as an interface between the user and the logic layer.
+- **Deployables**: This layer contains the final projects to be build. 
+	- *pg-console-genpwd*: Entry point for the genpwd command. Provides the console application to generate the passwords and outputs the messages to the user. Any other console commands can be implemented here in the future.
 - **Tests**: Provides the unit tests for the logic layer. This project is also divided into the same layers as the main solution.
 
 Every layer contains its own specific exceptions to handle custom errors. Exceptions are only thrown for exceptional cases, expected cases are handled by the return values. Exceptions are catched in the layer that can handle them and rethrown (or not catched) if necessary. Rethrowning a new exception is allowed to provide more context to the caller, but always including the original exception as the inner exception.
-
-Additional information may be added to a rethrown exception to provide more context to the caller.
 
 ## Strategies
 ### Random Strategy

--- a/pg-console-genpwd/Program.cs
+++ b/pg-console-genpwd/Program.cs
@@ -3,7 +3,7 @@ using PG.Data.Files.DataFiles;
 using PG.Interface.Command.PasswordGeneration;
 using PG.Interface.Command.PasswordGeneration.Entities;
 using PG.Logic.Passwords.Generators;
-using PG.Logic.Passwords.Loader;
+using PG.Logic.Passwords.Loaders;
 using PG.Shared.Services;
 
 namespace PG.Console.PasswordGenie

--- a/pg-console-genpwd/Program.cs
+++ b/pg-console-genpwd/Program.cs
@@ -8,11 +8,11 @@ using PG.Shared.Services;
 
 namespace PG.Console.PasswordGenie
 {
-    static class Program
+	internal static class Program
 	{
 		private static readonly ServiceProvider _provider = GetServiceProvider();
 
-		static async Task<int> Main(string[] args)
+		private static async Task<int> Main(string[] args)
 		{
 			PassGenieParser passGenieParser = _provider.GetRequiredService<PassGenieParser>();
 			passGenieParser.OutputReport += HandleOutputReport;

--- a/pg-console-genpwd/Program.cs
+++ b/pg-console-genpwd/Program.cs
@@ -2,6 +2,7 @@
 using PG.Data.Files.DataFiles;
 using PG.Interface.Command.PasswordGeneration;
 using PG.Interface.Command.PasswordGeneration.Entities;
+using PG.Logic.Passwords.Extractors;
 using PG.Logic.Passwords.Generators;
 using PG.Logic.Passwords.Loaders;
 using PG.Shared.Services;
@@ -57,6 +58,7 @@ namespace PG.Console.PasswordGenie
 			return new ServiceCollection()
 				.AddSingleton<PassGenieParser>()
 				.AddSingleton<PasswordGeneratorFactory>()
+				.AddSingleton<WordExtractorFactory>()
 				.AddSingleton<IDictionaryLoaderFactory, DictionaryLoaderFactory>()
 				.AddSingleton<IDictionariesDataFactory, DictionariesDataFactory>()
 				.AddTransient<RandomService>()

--- a/pg-data-files/DataFiles/Dictionaries/IDictionariesData.cs
+++ b/pg-data-files/DataFiles/Dictionaries/IDictionariesData.cs
@@ -1,10 +1,10 @@
 ﻿namespace PG.Data.Files.DataFiles.Dictionaries
 {
-    /// <summary>
-    /// Represents a data source for dictionaries to get words from.
-    /// </summary>
-    public interface IDictionariesData
-    {
-        IEnumerable<string> FetchAllWords(Stream fileStream);
-    }
+	/// <summary>
+	/// Represents a data source for dictionaries to get words from.
+	/// </summary>
+	public interface IDictionariesData
+	{
+		IEnumerable<string> FetchAllWords(Stream fileStream);
+	}
 }

--- a/pg-data-files/DataFiles/DictionariesDataFactory.cs
+++ b/pg-data-files/DataFiles/DictionariesDataFactory.cs
@@ -1,5 +1,6 @@
 ﻿using PG.Data.Files.DataFiles.Dictionaries;
 using PG.Data.Files.DataFiles.WordTrees;
+using PG.Entities.Files;
 using System.Text;
 
 namespace PG.Data.Files.DataFiles

--- a/pg-data-files/DataFiles/IDictionariesDataFactory.cs
+++ b/pg-data-files/DataFiles/IDictionariesDataFactory.cs
@@ -1,5 +1,6 @@
 ﻿using PG.Data.Files.DataFiles.Dictionaries;
 using PG.Data.Files.DataFiles.WordTrees;
+using PG.Entities.Files;
 using System.Text;
 
 namespace PG.Data.Files.DataFiles

--- a/pg-entities/Files/DictionaryType.cs
+++ b/pg-entities/Files/DictionaryType.cs
@@ -1,4 +1,4 @@
-﻿namespace PG.Data.Files.DataFiles
+﻿namespace PG.Entities.Files
 {
 	public enum DictionaryType { PlainTextDictionary, WordTree }
 }

--- a/pg-entities/WordTrees/TreeNode.cs
+++ b/pg-entities/WordTrees/TreeNode.cs
@@ -44,7 +44,7 @@ namespace PG.Entities.WordTrees
 		public static bool operator !=(TreeNode<T>? left, TreeNode<T>? right)
 		{
 			return !(left == right);
-		} 
+		}
 		#endregion
 
 		public override string ToString() => $"{Value} (+{Children.Count})";

--- a/pg-entities/WordTrees/TreeRoot.cs
+++ b/pg-entities/WordTrees/TreeRoot.cs
@@ -30,7 +30,7 @@ namespace PG.Entities.WordTrees
 		public static bool operator !=(TreeRoot<T>? left, TreeRoot<T>? right)
 		{
 			return !(left == right);
-		} 
+		}
 		#endregion
 
 		public override string ToString() => $"{Children.Count} children";

--- a/pg-entities/WordTrees/WordDictionaryTree.cs
+++ b/pg-entities/WordTrees/WordDictionaryTree.cs
@@ -30,7 +30,7 @@ namespace PG.Entities.WordTrees
 		public static bool operator !=(WordDictionaryTree? left, WordDictionaryTree? right)
 		{
 			return !(left == right);
-		} 
+		}
 		#endregion
 
 		public override string ToString() => $"{Root.Children.Count} nodes";

--- a/pg-interface-cmd/PasswordGeneration/Entities/CommonSettings.cs
+++ b/pg-interface-cmd/PasswordGeneration/Entities/CommonSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace PG.Interface.Command.PasswordGeneration.Entities
+{
+	internal abstract class CommonSettings
+	{
+		public bool Verbose { get; set; }
+	}
+}

--- a/pg-interface-cmd/PasswordGeneration/Entities/ExtractorSettings.cs
+++ b/pg-interface-cmd/PasswordGeneration/Entities/ExtractorSettings.cs
@@ -1,0 +1,9 @@
+﻿namespace PG.Interface.Command.PasswordGeneration.Entities
+{
+	internal class ExtractorSettings : CommonSettings
+	{
+		public FileInfo? Input { get; set; }
+		public FileInfo? Output { get; set; }
+		public bool Overwrite { get; set; } = false;
+	}
+}

--- a/pg-interface-cmd/PasswordGeneration/Entities/GeneratorSettings.cs
+++ b/pg-interface-cmd/PasswordGeneration/Entities/GeneratorSettings.cs
@@ -2,7 +2,7 @@
 
 namespace PG.Interface.Command.PasswordGeneration.Entities
 {
-	internal class PassGenieSettings
+	internal class GeneratorSettings : CommonSettings
 	{
 		// Common options
 		public int NumberOfPasswords { get; set; } = 1;
@@ -14,7 +14,6 @@ namespace PG.Interface.Command.PasswordGeneration.Entities
 		public bool IncludeSeparatorSymbols { get; set; } = true;
 		public string CustomSymbols { get; set; } = string.Empty;
 		public bool RemoveHighAsciiTable { get; set; } = false;
-		public bool Verbose { get; set; }
 
 		// Options for the random strategy
 		public int NumberOfLetters { get; set; } = 10;

--- a/pg-interface-cmd/PasswordGeneration/PassGenieParser.cs
+++ b/pg-interface-cmd/PasswordGeneration/PassGenieParser.cs
@@ -1,4 +1,4 @@
-﻿using PG.Data.Files.DataFiles;
+﻿using PG.Entities.Files;
 using PG.Interface.Command.PasswordGeneration.Entities;
 using PG.Logic.Passwords.Generators;
 using PG.Logic.Passwords.Generators.Entities;

--- a/pg-interface-cmd/PasswordGeneration/PassGenieParser.cs
+++ b/pg-interface-cmd/PasswordGeneration/PassGenieParser.cs
@@ -1,5 +1,7 @@
 ﻿using PG.Entities.Files;
 using PG.Interface.Command.PasswordGeneration.Entities;
+using PG.Logic.Passwords.Extractors;
+using PG.Logic.Passwords.Extractors.Entities;
 using PG.Logic.Passwords.Generators;
 using PG.Logic.Passwords.Generators.Entities;
 using PG.Shared.ErrorHandling;
@@ -28,6 +30,7 @@ namespace PG.Interface.Command.PasswordGeneration
 		{
 			RootCommand rootCommand = CreateRootCommand();
 			rootCommand.AddCommand(CreateGenerationCommand());
+			rootCommand.AddCommand(CreateExtractionCommand());
 
 			Parser parser = new CommandLineBuilder(rootCommand)
 				.UseVersionOption("--Version", "-v")
@@ -47,15 +50,6 @@ namespace PG.Interface.Command.PasswordGeneration
 		private static RootCommand CreateRootCommand()
 		{
 			var command = new RootCommand("Generates passwords based on different strategies and options");
-			command.AddGlobalOption(new Option<int>(["--NumberOfPasswords", "-p"], () => 1, "Number of passwords to generate"));
-			command.AddGlobalOption(new Option<int>(["--Length", "-l"], () => 12, "Length of the password (approximate)"));
-			command.AddGlobalOption(new Option<int>(["--NumberOfNumbers", "-n"], () => 1, "Number of numbers in the password"));
-			command.AddGlobalOption(new Option<int>(["--NumberOfSpecialCharacters", "-s"], () => 1, "Number of special characters in the password"));
-			command.AddGlobalOption(new Option<bool>(["--IncludeGroupSymbols", "-sg"], () => true, @"Include group symbols ('()[]{}<>') in the password."));
-			command.AddGlobalOption(new Option<bool>(["--IncludeMarkSymbols", "-sm"], () => true, @"Include mark symbols ('!@#$%^*+=|;:\""?') in the password."));
-			command.AddGlobalOption(new Option<bool>(["--IncludeSeparatorSymbols", "-sp"], () => true, @"Include separator symbols (' -_/\&,.') in the password."));
-			command.AddGlobalOption(new Option<string>(["--CustomSymbols", "-sc"], () => string.Empty, "Use custom set of symbols. All 'Include' options are ignored."));
-			command.AddGlobalOption(new Option<bool>(["--RemoveHighAsciiTable", "-r"], () => false, @"Remove characters of the high ASCII table (128-255) from the password."));
 			command.AddGlobalOption(new Option<bool>(["--Verbose"], "Show additional information about the generated password."));
 
 			return command;
@@ -65,6 +59,17 @@ namespace PG.Interface.Command.PasswordGeneration
 		{
 			var command = new System.CommandLine.Command("generate", "Generates passwords based on different strategies and options");
 			command.AddArgument(new Argument<GeneratorType>("type", "The strategy to use for generating the password"));
+
+			// Options for both of the strategies
+			command.AddOption(new Option<int>(["--NumberOfPasswords", "-p"], () => 1, "Number of passwords to generate"));
+			command.AddOption(new Option<int>(["--Length", "-l"], () => 12, "Length of the password (approximate)"));
+			command.AddOption(new Option<int>(["--NumberOfNumbers", "-n"], () => 1, "Number of numbers in the password"));
+			command.AddOption(new Option<int>(["--NumberOfSpecialCharacters", "-s"], () => 1, "Number of special characters in the password"));
+			command.AddOption(new Option<bool>(["--IncludeGroupSymbols", "-sg"], () => true, @"Include group symbols ('()[]{}<>') in the password."));
+			command.AddOption(new Option<bool>(["--IncludeMarkSymbols", "-sm"], () => true, @"Include mark symbols ('!@#$%^*+=|;:\""?') in the password."));
+			command.AddOption(new Option<bool>(["--IncludeSeparatorSymbols", "-sp"], () => true, @"Include separator symbols (' -_/\&,.') in the password."));
+			command.AddOption(new Option<string>(["--CustomSymbols", "-sc"], () => string.Empty, "Use custom set of symbols. All 'Include' options are ignored."));
+			command.AddOption(new Option<bool>(["--RemoveHighAsciiTable", "-r"], () => false, @"Remove characters of the high ASCII table (128-255) from the password."));
 
 			// Options for the random strategy
 			command.AddOption(new Option<int>(["--NumberOfLetters", "-c"], () => 10, "Number of letters in the password"));
@@ -83,7 +88,7 @@ namespace PG.Interface.Command.PasswordGeneration
 			command.AddOption(new Option<KeystrokeOrder>(["--KeystrokeOrder", "-ko"], () => KeystrokeOrder.Random,
 				$"The order in which keystrokes are generated ({string.Join(", ", Enum.GetNames(typeof(KeystrokeOrder)))})"));
 
-			command.Handler = CommandHandler.Create<GeneratorType, PassGenieSettings>(ExecuteCommand);
+			command.Handler = CommandHandler.Create<GeneratorType, GeneratorSettings>(ExecuteGeneration);
 
 			return command;
 
@@ -98,7 +103,21 @@ namespace PG.Interface.Command.PasswordGeneration
 			}
 		}
 
-		private int ExecuteCommand(GeneratorType type, PassGenieSettings settings)
+		private System.CommandLine.Command CreateExtractionCommand()
+		{
+			var command = new System.CommandLine.Command("extract", "Generates passwords based on different strategies and options");
+			command.AddArgument(new Argument<DictionaryFormat>("format", "The format of the dictionary"));
+
+			command.AddOption(new Option<FileInfo>(["--Input", "-i"], "File path for the dictionary file"));
+			command.AddOption(new Option<FileInfo>(["--Output", "-o"], "File path for the generated word tree file"));
+			command.AddOption(new Option<bool>(["--Overwrite", "-ow"], () => false, "Overwrite the output file if it already exists"));
+
+			command.Handler = CommandHandler.Create<DictionaryFormat, ExtractorSettings>(ExecuteExtraction);
+
+			return command;
+		}
+
+		private int ExecuteGeneration(GeneratorType type, GeneratorSettings settings)
 		{
 			var factory = _provider.GetService(typeof(PasswordGeneratorFactory)) as PasswordGeneratorFactory
 				?? throw new InvalidOperationException("Password generator factory is not registered as a service provider.");
@@ -119,7 +138,7 @@ namespace PG.Interface.Command.PasswordGeneration
 			return NO_ERROR;
 		}
 
-		private static RandomPasswordGeneratorOptions ConvertToRandomGeneratorOptions(PassGenieSettings settings)
+		private static RandomPasswordGeneratorOptions ConvertToRandomGeneratorOptions(GeneratorSettings settings)
 		{
 			return new()
 			{
@@ -136,7 +155,7 @@ namespace PG.Interface.Command.PasswordGeneration
 			};
 		}
 
-		private static DictionaryPasswordGeneratorOptions ConvertToDictionaryGeneratorOptions(PassGenieSettings settings)
+		private static DictionaryPasswordGeneratorOptions ConvertToDictionaryGeneratorOptions(GeneratorSettings settings)
 		{
 			FileInfo file = settings.Dictionary ?? settings.WordTree
 				?? throw new InvalidDictionaryException("Dictionary or word tree file path is required for the dictionary strategy.");
@@ -173,19 +192,6 @@ namespace PG.Interface.Command.PasswordGeneration
 			};
 		}
 
-		private void HandleCommandException(Exception exception, InvocationContext context)
-		{
-			if (exception is TargetInvocationException targetInvocationException)
-				exception = targetInvocationException.InnerException ?? exception;
-
-			if (exception is BaseException baseException)
-				Output(TraceLevel.Warning, "{0}", baseException.Message);
-			else
-				Output(TraceLevel.Error, "{0}", exception.Message);
-
-			context.ExitCode = UNEXPECTED_ERROR;
-		}
-
 		/// <summary>
 		/// Using predefined ranges, returns a text representation of the entropy.
 		/// </summary>
@@ -202,6 +208,45 @@ namespace PG.Interface.Command.PasswordGeneration
 			if (entropy < 128)
 				return "Strong";
 			return "Very strong";
+		}
+
+		private int ExecuteExtraction(DictionaryFormat format, ExtractorSettings settings)
+		{
+			FileInfo inputFile = settings.Input
+				?? throw new InvalidDictionaryException("Input file is required to extract the words.");
+
+			if (!inputFile.Exists)
+				throw new InvalidDictionaryException($"Data file '{inputFile.FullName}' does not exist.");
+
+			FileInfo outputFile = settings.Output
+				?? throw new InvalidDictionaryException("Ouput file is required to save extracted words.");
+
+			if (outputFile.Exists && !settings.Overwrite)
+				throw new InvalidDictionaryException("Output file already exists, overwrite option is not enabled");
+
+			var factory = _provider.GetService(typeof(WordExtractorFactory)) as WordExtractorFactory
+				?? throw new InvalidOperationException("Word extractor factory is not registered as a service provider.");
+
+			IWordExtractor extractor = factory.Create(format);
+
+			using (Stream inputStream = new FileStream(inputFile.FullName, FileMode.Open, FileAccess.Read, FileShare.Read))
+			using (Stream outputStream = new FileStream(outputFile.FullName, FileMode.Create, FileAccess.Write, FileShare.Read))
+				extractor.ExtractWordTree(inputStream, outputStream);
+
+			return NO_ERROR;
+		}
+
+		private void HandleCommandException(Exception exception, InvocationContext context)
+		{
+			if (exception is TargetInvocationException targetInvocationException)
+				exception = targetInvocationException.InnerException ?? exception;
+
+			if (exception is BaseException baseException)
+				Output(TraceLevel.Warning, "{0}", baseException.Message);
+			else
+				Output(TraceLevel.Error, "{0}", exception.Message);
+
+			context.ExitCode = UNEXPECTED_ERROR;
 		}
 
 		private void Output(TraceLevel level, string format, params object[] args)

--- a/pg-logic/Passwords/Extractors/Entities/DictionaryFormat.cs
+++ b/pg-logic/Passwords/Extractors/Entities/DictionaryFormat.cs
@@ -1,0 +1,4 @@
+﻿namespace PG.Logic.Passwords.Extractors.Entities
+{
+	public enum DictionaryFormat { Plain }
+}

--- a/pg-logic/Passwords/Extractors/IWordExtractor.cs
+++ b/pg-logic/Passwords/Extractors/IWordExtractor.cs
@@ -1,0 +1,7 @@
+﻿namespace PG.Logic.Passwords.Extractors
+{
+	public interface IWordExtractor
+	{
+		void ExtractWordTree(Stream inputStream, Stream outputStream);
+	}
+}

--- a/pg-logic/Passwords/Extractors/PlainTextWordExtractor.cs
+++ b/pg-logic/Passwords/Extractors/PlainTextWordExtractor.cs
@@ -1,0 +1,18 @@
+﻿using PG.Data.Files.DataFiles.WordTrees;
+using PG.Entities.WordTrees;
+using PG.Logic.Passwords.Loaders;
+
+namespace PG.Logic.Passwords.Extractors
+{
+	public class PlainTextWordExtractor(IDictionaryLoader loader) : IWordExtractor
+	{
+		private readonly IDictionaryLoader _loader = loader;
+
+		public void ExtractWordTree(Stream inputStream, Stream outputStream)
+		{
+			WordDictionaryTree wordTree = _loader.Load(inputStream);
+
+			new BinaryWordTreeFile().SaveTree(outputStream, wordTree);
+		}
+	}
+}

--- a/pg-logic/Passwords/Extractors/WordExtractorFactory.cs
+++ b/pg-logic/Passwords/Extractors/WordExtractorFactory.cs
@@ -1,0 +1,26 @@
+﻿using PG.Entities.Files;
+using PG.Logic.Common;
+using PG.Logic.Passwords.Extractors.Entities;
+using PG.Logic.Passwords.Loaders;
+
+namespace PG.Logic.Passwords.Extractors
+{
+	public class WordExtractorFactory(IServiceProvider provider)
+	{
+		private readonly IServiceProvider _provider = provider;
+
+		public IWordExtractor Create(DictionaryFormat format)
+		{
+			IDictionaryLoaderFactory loaderFactory = _provider.GetService(typeof(IDictionaryLoaderFactory)) as IDictionaryLoaderFactory
+				?? throw new InvalidOperationException("Dictionary loader factory is not registered as a service provider.");
+
+			IDictionaryLoader loader = format switch
+			{
+				DictionaryFormat.Plain => loaderFactory.CreateForDictionary(DictionaryType.PlainTextDictionary, Constants.DictionaryEncoding),
+				_ => throw new InvalidOperationException($"Invalid generator type ('{format}')")
+			};
+
+			return new PlainTextWordExtractor(loader);
+		}
+	}
+}

--- a/pg-logic/Passwords/Generators/DictionaryPasswordGenerator.cs
+++ b/pg-logic/Passwords/Generators/DictionaryPasswordGenerator.cs
@@ -233,7 +233,7 @@ namespace PG.Logic.Passwords.Generators
 				if (children.Count == 0) break;
 
 				var next = children[_random.Next(children.Count)];
-				wordBuilder.Append(next.Value);
+				wordBuilder = wordBuilder.Append(next.Value);
 
 				curFinger = GetFingerForKeystroke(next.Value);
 

--- a/pg-logic/Passwords/Generators/DictionaryPasswordGenerator.cs
+++ b/pg-logic/Passwords/Generators/DictionaryPasswordGenerator.cs
@@ -1,7 +1,6 @@
 ﻿using PG.Entities.WordTrees;
 using PG.Logic.Common;
 using PG.Logic.Passwords.Generators.Entities;
-using PG.Logic.Passwords.Loader;
 using PG.Shared.Extensions;
 using PG.Shared.Services;
 using System.Text;

--- a/pg-logic/Passwords/Generators/Entities/DictionaryPasswordGeneratorOptions.cs
+++ b/pg-logic/Passwords/Generators/Entities/DictionaryPasswordGeneratorOptions.cs
@@ -1,4 +1,4 @@
-﻿using PG.Data.Files.DataFiles;
+﻿using PG.Entities.Files;
 
 namespace PG.Logic.Passwords.Generators.Entities
 {

--- a/pg-logic/Passwords/Generators/PasswordGeneratorFactory.cs
+++ b/pg-logic/Passwords/Generators/PasswordGeneratorFactory.cs
@@ -2,7 +2,7 @@
 using PG.Entities.WordTrees;
 using PG.Logic.Common;
 using PG.Logic.Passwords.Generators.Entities;
-using PG.Logic.Passwords.Loader;
+using PG.Logic.Passwords.Loaders;
 using PG.Shared.Services;
 
 namespace PG.Logic.Passwords.Generators

--- a/pg-logic/Passwords/Generators/PasswordGeneratorFactory.cs
+++ b/pg-logic/Passwords/Generators/PasswordGeneratorFactory.cs
@@ -1,4 +1,4 @@
-﻿using PG.Data.Files.DataFiles;
+﻿using PG.Entities.Files;
 using PG.Entities.WordTrees;
 using PG.Logic.Common;
 using PG.Logic.Passwords.Generators.Entities;

--- a/pg-logic/Passwords/Loader/DictionaryLoaderFactory.cs
+++ b/pg-logic/Passwords/Loader/DictionaryLoaderFactory.cs
@@ -1,7 +1,7 @@
 ﻿using PG.Data.Files.DataFiles;
 using PG.Data.Files.DataFiles.Dictionaries;
 using PG.Data.Files.DataFiles.WordTrees;
-using System.Reflection;
+using PG.Entities.Files;
 using System.Text;
 
 namespace PG.Logic.Passwords.Loader

--- a/pg-logic/Passwords/Loader/IDictionaryLoaderFactory.cs
+++ b/pg-logic/Passwords/Loader/IDictionaryLoaderFactory.cs
@@ -1,5 +1,5 @@
-﻿using PG.Data.Files.DataFiles;
-using PG.Data.Files.DataFiles.WordTrees;
+﻿using PG.Data.Files.DataFiles.WordTrees;
+using PG.Entities.Files;
 using System.Text;
 
 namespace PG.Logic.Passwords.Loader

--- a/pg-logic/Passwords/Loader/WordDictionaryLoader.cs
+++ b/pg-logic/Passwords/Loader/WordDictionaryLoader.cs
@@ -5,7 +5,7 @@ using static PG.Logic.ErrorHandling.BusinessExceptions;
 
 namespace PG.Logic.Passwords.Loader
 {
-    public class WordDictionaryLoader(IDictionariesData data) : IDictionaryLoader
+	public class WordDictionaryLoader(IDictionariesData data) : IDictionaryLoader
 	{
 		private const int MINIMUM_WORD_LENGTH = 2;
 		private readonly HashSet<char> VOWEL_AND_DIACRITIC_CHARS = [

--- a/pg-logic/Passwords/Loaders/DictionaryLoaderFactory.cs
+++ b/pg-logic/Passwords/Loaders/DictionaryLoaderFactory.cs
@@ -4,7 +4,7 @@ using PG.Data.Files.DataFiles.WordTrees;
 using PG.Entities.Files;
 using System.Text;
 
-namespace PG.Logic.Passwords.Loader
+namespace PG.Logic.Passwords.Loaders
 {
 	public class DictionaryLoaderFactory(IServiceProvider provider) : IDictionaryLoaderFactory
 	{

--- a/pg-logic/Passwords/Loaders/IDictionaryLoader.cs
+++ b/pg-logic/Passwords/Loaders/IDictionaryLoader.cs
@@ -1,6 +1,6 @@
 ﻿using PG.Entities.WordTrees;
 
-namespace PG.Logic.Passwords.Loader
+namespace PG.Logic.Passwords.Loaders
 {
 	public interface IDictionaryLoader
 	{

--- a/pg-logic/Passwords/Loaders/IDictionaryLoaderFactory.cs
+++ b/pg-logic/Passwords/Loaders/IDictionaryLoaderFactory.cs
@@ -2,7 +2,7 @@
 using PG.Entities.Files;
 using System.Text;
 
-namespace PG.Logic.Passwords.Loader
+namespace PG.Logic.Passwords.Loaders
 {
 	public interface IDictionaryLoaderFactory
 	{

--- a/pg-logic/Passwords/Loaders/WordDictionaryLoader.cs
+++ b/pg-logic/Passwords/Loaders/WordDictionaryLoader.cs
@@ -3,7 +3,7 @@ using PG.Entities.WordTrees;
 using PG.Shared.Extensions;
 using static PG.Logic.ErrorHandling.BusinessExceptions;
 
-namespace PG.Logic.Passwords.Loader
+namespace PG.Logic.Passwords.Loaders
 {
 	public class WordDictionaryLoader(IDictionariesData data) : IDictionaryLoader
 	{

--- a/pg-shared/Extensions/TextExtensions.cs
+++ b/pg-shared/Extensions/TextExtensions.cs
@@ -5,8 +5,8 @@ namespace PG.Shared.Extensions
 	public static class TextExtensions
 	{
 		private static readonly HashSet<char> WhitespaceCharacters = new([
-		  ' ', '\t', '\n', '\r', '\v', '\f',
-		  '\u00A0', '\u2000', '\u2001', '\u2002', '\u2003', '\u2004', '\u2005', '\u2006', '\u2007', '\u2008', '\u2009', '\u200A', '\u200B', '\u202F', '\u205F', '\u3000'
+			' ', '\t', '\n', '\r', '\v', '\f',
+			'\u00A0', '\u2000', '\u2001', '\u2002', '\u2003', '\u2004', '\u2005', '\u2006', '\u2007', '\u2008', '\u2009', '\u200A', '\u200B', '\u202F', '\u205F', '\u3000'
 		]);
 
 		/// <summary>
@@ -14,7 +14,7 @@ namespace PG.Shared.Extensions
 		/// </summary>
 		/// <param name="c">The character to check.</param>
 		/// <returns><c>true</c> if the character is printable; otherwise, <c>false</c>.</returns>
-		public static bool IsPrintable(this char c) => (c > 32 && c <= 126) || c >= 128 && c <= 255;
+		public static bool IsPrintable(this char c) => (c > 32 && c <= 126) || (c >= 128 && c <= 255);
 
 		/// <summary>
 		/// Determines if a character is any type of space.

--- a/pg-tests/Business/Passwords/Extractors/PlainTextWordExtractorTests.cs
+++ b/pg-tests/Business/Passwords/Extractors/PlainTextWordExtractorTests.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using PG.Data.Files.DataFiles;
+using PG.Data.Files.DataFiles.WordTrees;
+using PG.Entities.WordTrees;
+using PG.Logic.Passwords.Extractors;
+using PG.Logic.Passwords.Extractors.Entities;
+using PG.Logic.Passwords.Generators;
+using PG.Logic.Passwords.Loaders;
+using PG.Shared.Services;
+using System.Text;
+
+namespace PG.Tests.Business.Passwords.Extractors
+{
+	[TestClass()]
+	public class PlainTextWordExtractorTests
+	{
+		private readonly ServiceProvider _provider;
+		private readonly WordExtractorFactory _factory;
+
+		public PlainTextWordExtractorTests()
+		{
+			_provider = new ServiceCollection()
+				.AddSingleton<PasswordGeneratorFactory>()
+				.AddSingleton<WordExtractorFactory>()
+				.AddSingleton<IDictionaryLoaderFactory, DictionaryLoaderFactory>()
+				.AddSingleton<IDictionariesDataFactory, DictionariesDataFactory>()
+				.AddTransient<RandomService>()
+				.BuildServiceProvider();
+
+			_factory = new WordExtractorFactory(_provider);
+		}
+
+		[TestMethod()]
+		public void ExtractWordTreeTest()
+		{
+			// Load some words into a Memory stream, each word separated by a new line.
+			var text = string.Join(Environment.NewLine, ["aone", "atwo", "athree"]);
+			MemoryStream input = new(Encoding.UTF8.GetBytes(text));
+			MemoryStream output = new();
+
+			_factory.Create(DictionaryFormat.Plain).ExtractWordTree(input, output);
+
+			MemoryStream outputStreamCopy = new(output.ToArray());
+			WordDictionaryTree tree = new BinaryWordTreeFile().FetchTree(outputStreamCopy);
+
+			ITreeNode<string> node = tree.Root;
+			Assert.AreEqual(1, node.Children.Count, "Unexpected letter count for first level");
+			Assert.AreEqual("a", node.Children.First().Key, "Unexpected letter for first level");
+
+			node = node.Children.First().Value;
+			Assert.AreEqual(2, node.Children.Count, "Unexpected letter count for first level");
+			Assert.AreEqual("o", node.Children.First().Key, "Unexpected letter for first level");
+		}
+	}
+}

--- a/pg-tests/Business/Passwords/Generators/DictionaryPasswordGeneratorTests.cs
+++ b/pg-tests/Business/Passwords/Generators/DictionaryPasswordGeneratorTests.cs
@@ -4,7 +4,7 @@ using PG.Entities.Files;
 using PG.Entities.WordTrees;
 using PG.Logic.Passwords.Generators;
 using PG.Logic.Passwords.Generators.Entities;
-using PG.Logic.Passwords.Loader;
+using PG.Logic.Passwords.Loaders;
 using PG.Shared.Services;
 using PG.Tests.Business.Passwords.Generators.Mockups;
 using System.Diagnostics;

--- a/pg-tests/Business/Passwords/Generators/DictionaryPasswordGeneratorTests.cs
+++ b/pg-tests/Business/Passwords/Generators/DictionaryPasswordGeneratorTests.cs
@@ -1,5 +1,6 @@
 ﻿using PG.Data.Files.DataFiles;
 using PG.Data.Files.DataFiles.Dictionaries;
+using PG.Entities.Files;
 using PG.Entities.WordTrees;
 using PG.Logic.Passwords.Generators;
 using PG.Logic.Passwords.Generators.Entities;
@@ -239,7 +240,7 @@ namespace PG.Tests.Business.Passwords.Generators
 
 			try
 			{
-				wordTree =  new WordDictionaryLoader(new DictionaryDataMockup(["qwertasdfgzxcvb", "yuiophjklnm"])).Load(null!);
+				wordTree = new WordDictionaryLoader(new DictionaryDataMockup(["qwertasdfgzxcvb", "yuiophjklnm"])).Load(null!);
 				_ = new DictionaryPasswordGenerator(options, new RandomService(), wordTree).Generate();
 				Assert.Fail("Expected exception 'Max iterations reached without being able to generate a valid word.' not thrown.");
 			}

--- a/pg-tests/Business/Passwords/Loader/WordDictionaryLoaderTests.cs
+++ b/pg-tests/Business/Passwords/Loader/WordDictionaryLoaderTests.cs
@@ -1,5 +1,6 @@
 ﻿using PG.Data.Files.DataFiles;
 using PG.Data.Files.DataFiles.Dictionaries;
+using PG.Entities.Files;
 using PG.Entities.WordTrees;
 using PG.Logic.Passwords.Loader;
 using System.Text;

--- a/pg-tests/Business/Passwords/Loader/WordDictionaryLoaderTests.cs
+++ b/pg-tests/Business/Passwords/Loader/WordDictionaryLoaderTests.cs
@@ -2,7 +2,7 @@
 using PG.Data.Files.DataFiles.Dictionaries;
 using PG.Entities.Files;
 using PG.Entities.WordTrees;
-using PG.Logic.Passwords.Loader;
+using PG.Logic.Passwords.Loaders;
 using System.Text;
 
 namespace PG.Tests.Business.Passwords.Loader

--- a/pg-tests/Data/Dictionaries/TextDictionaryFileTests.cs
+++ b/pg-tests/Data/Dictionaries/TextDictionaryFileTests.cs
@@ -1,5 +1,6 @@
 ﻿using PG.Data.Files.DataFiles;
 using PG.Data.Files.DataFiles.Dictionaries;
+using PG.Entities.Files;
 using System.Diagnostics;
 using System.Text;
 

--- a/pg-tests/Data/WordTrees/WordTreeFileTests.cs
+++ b/pg-tests/Data/WordTrees/WordTreeFileTests.cs
@@ -3,7 +3,7 @@ using PG.Data.Files.DataFiles.Dictionaries;
 using PG.Data.Files.DataFiles.WordTrees;
 using PG.Entities.Files;
 using PG.Entities.WordTrees;
-using PG.Logic.Passwords.Loader;
+using PG.Logic.Passwords.Loaders;
 using PG.Shared.Extensions;
 using System.Diagnostics;
 using System.Text;

--- a/pg-tests/Data/WordTrees/WordTreeFileTests.cs
+++ b/pg-tests/Data/WordTrees/WordTreeFileTests.cs
@@ -1,6 +1,7 @@
 ﻿using PG.Data.Files.DataFiles;
 using PG.Data.Files.DataFiles.Dictionaries;
 using PG.Data.Files.DataFiles.WordTrees;
+using PG.Entities.Files;
 using PG.Entities.WordTrees;
 using PG.Logic.Passwords.Loader;
 using PG.Shared.Extensions;

--- a/pg-tests/Interface/PasswordGeneration/PassGenieParserTests.cs
+++ b/pg-tests/Interface/PasswordGeneration/PassGenieParserTests.cs
@@ -7,7 +7,7 @@ using PG.Shared.Services;
 
 namespace PG.Tests.Interface.PasswordGeneration
 {
-    [TestClass()]
+	[TestClass()]
 	public class PassGenieParserTests
 	{
 		private readonly ServiceProvider _provider;

--- a/pg-tests/Interface/PasswordGeneration/PassGenieParserTests.cs
+++ b/pg-tests/Interface/PasswordGeneration/PassGenieParserTests.cs
@@ -2,7 +2,7 @@
 using PG.Data.Files.DataFiles;
 using PG.Interface.Command.PasswordGeneration;
 using PG.Logic.Passwords.Generators;
-using PG.Logic.Passwords.Loader;
+using PG.Logic.Passwords.Loaders;
 using PG.Shared.Services;
 
 namespace PG.Tests.Interface.PasswordGeneration

--- a/pg-tests/Interface/PasswordGeneration/PassGenieParserTests.cs
+++ b/pg-tests/Interface/PasswordGeneration/PassGenieParserTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using PG.Data.Files.DataFiles;
 using PG.Interface.Command.PasswordGeneration;
+using PG.Logic.Passwords.Extractors;
 using PG.Logic.Passwords.Generators;
 using PG.Logic.Passwords.Loaders;
 using PG.Shared.Services;
@@ -16,6 +17,7 @@ namespace PG.Tests.Interface.PasswordGeneration
 		{
 			_provider = new ServiceCollection()
 				.AddSingleton<PasswordGeneratorFactory>()
+				.AddSingleton<WordExtractorFactory>()
 				.AddSingleton<IDictionaryLoaderFactory, DictionaryLoaderFactory>()
 				.AddSingleton<IDictionariesDataFactory, DictionariesDataFactory>()
 				.AddTransient<RandomService>()
@@ -85,6 +87,22 @@ namespace PG.Tests.Interface.PasswordGeneration
 			int result = new PassGenieParser(_provider).ParseAndExecute(arguments).Result;
 
 			Assert.AreEqual(0, result, "Unexpected result");
+		}
+
+		[TestMethod]
+		public void ParseForWordExtractorTest()
+		{
+			string outputFilePath = @".\Resources\Dictionaries\words_alpha_esES_test.dat.gz";
+			string[] arguments = [
+				"extract", "plain",
+				"-i", @".\Resources\Dictionaries\words_alpha_esES.txt",
+				"-o", outputFilePath,
+			];
+
+			int result = new PassGenieParser(_provider).ParseAndExecute(arguments).Result;
+
+			Assert.AreEqual(0, result, "Unexpected result");
+			Assert.IsTrue(File.Exists(outputFilePath), "Output file not found");
 		}
 	}
 }

--- a/pg-tests/Resources/Scripts/Get-SuggestedPasswords.ps1
+++ b/pg-tests/Resources/Scripts/Get-SuggestedPasswords.ps1
@@ -1,8 +1,14 @@
 # This is a PowerShell script to generate a list of suggested passwords based on a dictionary.
-. ..\..\..\pg-console-genpwd\bin\Debug\net8.0\genpwd.exe generate random -p 5 -l 16 -n 2 -s 2 -c 12
+Write-Host "Generating passwords using random strategy..."
+. ..\..\..\pg-console-genpwd\bin\Debug\net8.0\genpwd.exe generate random -p 5 -l 16 -n 2 -s 2 -c 12 --Verbose
 
-. ..\..\..\pg-console-genpwd\bin\Debug\net8.0\genpwd.exe generate dictionary -wt ".\..\..\bin\Debug\net8.0\Resources\Dictionaries\word_tree_enUS.dat.gz" -p 5 -w 3 -wl 8 -wd 4
+Write-Host "Generating passwords using dictionary strategy based on a plain text file (en-US), 2 words, length 6, depth 4, random strokes..."
+. ..\..\..\pg-console-genpwd\bin\Debug\net8.0\genpwd.exe generate dictionary -d ".\..\..\bin\Debug\net8.0\Resources\Dictionaries\words_alpha_enUS.txt" -p 10 -w 2 -n 1 -s 1 -sc "-." -wl 6 -wd 4 --Verbose
 
-. ..\..\..\pg-console-genpwd\bin\Debug\net8.0\genpwd.exe generate dictionary -d ".\..\..\bin\Debug\net8.0\Resources\Dictionaries\words_alpha_enUS.txt" -p 10 -w 2 -n 1 -s 1 -sc "-." -wl 6 -wd 4 -ko AlternatingStroke
+Write-Host "Extracting word tree from plain text file (es-ES)..."
+. ..\..\..\pg-console-genpwd\bin\Debug\net8.0\genpwd.exe extract plain -i ".\..\..\bin\Debug\net8.0\Resources\Dictionaries\words_alpha_esES.txt" -o ".\..\..\bin\Debug\net8.0\Resources\Dictionaries\word_tree_esES_test.dat.gz" --Overwrite
+
+Write-Host "Generating passwords using dictionary strategy based on a word tree file (es-ES), 3 words, length 8, depth 4, alternating strokes..."
+. ..\..\..\pg-console-genpwd\bin\Debug\net8.0\genpwd.exe generate dictionary -wt ".\..\..\bin\Debug\net8.0\Resources\Dictionaries\word_tree_esES_test.dat.gz" -p 5 -w 2 -wl 7 -wd 4 -ko AlternatingStroke --Verbose
 
 Read-Host -Prompt "Press Enter to continue ::"

--- a/pg-tests/Shared/Extensions/TextExtensionsTests.cs
+++ b/pg-tests/Shared/Extensions/TextExtensionsTests.cs
@@ -26,7 +26,7 @@ namespace PG.Tests.Shared.Extensions
 		{
 			try
 			{
-				"".Right(0);
+				_ = "".Right(0);
 				Assert.Fail("Expected ArgumentOutOfRangeException");
 			}
 			catch (ArgumentOutOfRangeException) { /* Expected */ }

--- a/pg-wasm-pwdgen-demo/Program.cs
+++ b/pg-wasm-pwdgen-demo/Program.cs
@@ -8,9 +8,10 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) })
-		.AddSingleton<PasswordGeneratorFactory>()
-		.AddTransient<RandomService>()
-		.BuildServiceProvider();
+builder.Services
+	.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) })
+	.AddSingleton<PasswordGeneratorFactory>()
+	.AddTransient<RandomService>()
+	.BuildServiceProvider();
 
 await builder.Build().RunAsync();

--- a/pg-wasm-pwdgen-demo/Properties/launchSettings.json
+++ b/pg-wasm-pwdgen-demo/Properties/launchSettings.json
@@ -1,31 +1,33 @@
 {
-  "$schema": "http://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:55921",
-      "sslPort": 0
-    }
-  },
-  "profiles": {
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "http://localhost:5143",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    }
-  }
+	"$schema": "http://json.schemastore.org/launchsettings.json",
+	"iisSettings": {
+		"windowsAuthentication": false,
+		"anonymousAuthentication": true,
+		"iisExpress": {
+			"applicationUrl": "http://localhost:55921",
+			"sslPort": 0
+		}
+	},
+	"profiles": {
+		"http": {
+			"commandName": "Project",
+			"commandLineArgs": "--pathbase=/password-genie",
+			"dotnetRunMessages": true,
+			"launchBrowser": true,
+			"inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/password-genie/_framework/debug/ws-proxy?browser={browserInspectUri}",
+			"applicationUrl": "http://localhost:5143",
+			"launchUrl": "password-genie",
+			"environmentVariables": {
+				"ASPNETCORE_ENVIRONMENT": "Development"
+			}
+		},
+		"IIS Express": {
+			"commandName": "IISExpress",
+			"launchBrowser": true,
+			"inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+			"environmentVariables": {
+				"ASPNETCORE_ENVIRONMENT": "Development"
+			}
+		}
+	}
 }


### PR DESCRIPTION
pg-logic\Passwords\Extractors\WordExtractorFactory - New service to generate word tree files based on plain text files (#14).
pg-wasm-pwdgen-demo\Properties\launchSettings - Change base address to match GitHub's pages.
Rename namespace PG.Logic.Passwords.Loader > PG.Logic.Passwords.Loaders
Code clean up.
pg-entities\Files\DictionaryType - Move to the cross-cutting layer.
pg-logic\Passwords\Generators\PasswordGeneratorBase Solve Sonar complain S3776.
pg-data-files\DataFiles\Dictionaries\TextDictionaryFile - Avoid data to manage files directly. This will be necessary for the web version (#11, #13).
pg-interface-cmd\PasswordGeneration\PassGenieParser - New option to generate passwords based on a word tree (#11, #13)
pg-wasm-pwdgen-demo\wwwroot\sample-data - Add the binary word tree files to be available in the solution and for testing purposes (#11, #13).
pg-data-files - Move both dictionary and word tree data file managers to the same factory (#11, #13).
pg-logic\Passwords\Loader\WordDictionaryLoader - Move all non-loader related methods to DictionaryPasswordGenerator, return the word tree instead of storing it (#11 #13).
pg-data-files\WordTrees\BinaryWordTreeFile - Convert word tree to string nodes instead of char (#11, #12).
pg-data-files\WordTrees\BinaryWordTreeFile - Reduce data size for the word tree file structure (#11, #12). Add file size comparisson to the tests.
pg-data-files\WordTrees\BinaryWordTreeFile - Store the word tree into a binary compressed file (#11, #12).
pg-entities\WordTrees\ITreeNodeWithChildren - Rename
pg-data-files\Dictionaries\TextDictionaryFile - Code clarification.
pg-logic\pg-logic - Chage incorrect dependency with pg-entitites.
pg-logic\Passwords\Loader\Entities - Move entities to their own project (#11, #12).
